### PR TITLE
fix: update `Multicall` contract

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -390,7 +390,7 @@
     "shortName": "Moonbase",
     "chainId": 1287,
     "network": "testnet",
-    "multicall": "0xD7bA481DE7fB53A7a29641c43232B09e5D9CAe7b",
+    "multicall": "0xf09FD6B6FF3f41614b9d6be2166A0D07045A3A97",
     "rpc": ["https://rpc.testnet.moonbeam.network"],
     "explorer": "https://moonbase-blockscout.testnet.moonbeam.network/"
   },


### PR DESCRIPTION
When using the Moonbase Alpha network with Snapshot, we realized that we couldn't vote.

After doing some digging, we found that the issue was occurring when calling the `aggregate` function.

We have gone ahead and deployed a new `Multicall` contract (you can find the verified code [here](https://moonbase-blockscout.testnet.moonbeam.network/address/0xf09FD6B6FF3f41614b9d6be2166A0D07045A3A97/contracts)).